### PR TITLE
templates: version_selector: fix "stable" selection display

### DIFF
--- a/templates/version_selector.html
+++ b/templates/version_selector.html
@@ -2,7 +2,7 @@
         onchange="select_version(this)"
         class="w-full mt-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-300 focus:border-blue-300 block dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
     <option {% if "/docs/latest" in config.base_url %} selected {% endif %} value="/docs/latest/">Latest</option>
-    <option {% if "/docs/1.3" in config.base_url %} selected {% endif %} value="/docs/1.3/">1.3 (stable)</option>
+    <option {% if "/docs/stable" in config.base_url %} selected {% endif %} value="/docs/stable/">1.3 (stable)</option>
     <option {% if "/docs/1.2" in config.base_url %} selected {% endif %} value="/docs/1.2/">1.2</option>
     <option {% if "/docs/1.1" in config.base_url %} selected {% endif %} value="/docs/1.1/">1.1</option>
     <option {% if "/docs/1.0" in config.base_url %} selected {% endif %} value="/docs/1.0/">1.0</option>


### PR DESCRIPTION
Currently this isn't loading properly, because there is no real 1.3 path (it's a redirect to /stable).

This PR changes it to check for and link to the /stable path in the URL.
There may be some complexity when we want this whole list to be dynamic, but that's a later problem.