### PR TITLE
templates: base.html: add canonical links to stable docs

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title> BlueOS Documentation</title>
     <link href="{{ config.base_url | safe }}/output.css" rel="stylesheet">
+    {% if "/docs/stable" not in config.base_url %} {# Prioritise stable docs for online search indexing. #}
+      <link rel="canonical" href="{{ current_url | regex_replace(pattern=`\/docs\/[^\/]*`, rep=`/docs/stable`) | safe }}" />
+    {% endif %}
 </head>
 
 <body class="antialiased h-[calc(100vh-65px)]">


### PR DESCRIPTION
Recommends search engines prioritise the stable docs in indexing, instead of numbered releases or the development (latest) version.

This assumes the stable docs have the same paths available as the versioned and latest docs, which should _generally_ be true, but for the few cases where it's not (which should typically only occur in latest) the simplicity of the approach seems worth the potential reduction of search index performance, and the search engines are hopefully smart enough to figure out that a canonical path that doesn't exist shouldn't be preferred over a real page 🤷 

Closes #7.