### PR TITLE
Improve list and heading styling

### DIFF
--- a/input.css
+++ b/input.css
@@ -32,16 +32,29 @@
     }
 
     .markdown ul {
-        @apply list-disc list-inside text-lg ms-3
+        @apply list-disc list-outside text-lg ms-6
     }
 
     .markdown ol {
-        @apply list-decimal list-inside ms-3
+        @apply list-decimal list-outside text-lg ms-6
     }
 
     /* Ordered elements sometimes have a paragraph and even images inside it, need to change the display to inline */
-    .markdown ol p{
+    .markdown ol p {
         @apply inline
+    }
+
+    .markdown li {
+        @apply ps-2
+    }
+
+    /* Nested list items look nicer with different bullets, but tailwind doesn't support them */
+    .markdown li ul {
+        list-style-type: circle;
+    }
+
+    .markdown li li ul {
+        list-style-type: square;
     }
 
     /* Footnote element followed by a paragraph need to to change the display to inline. */
@@ -64,10 +77,6 @@
 
     .markdown a.zola-anchor {
         @apply no-underline -ms-6 me-2 text-gray-100 hover:text-gray-500
-    }
-
-    .markdown li ul {
-        @apply list-disc list-inside text-lg ms-6
     }
 
     .markdown img {

--- a/input.css
+++ b/input.css
@@ -23,6 +23,10 @@
         @apply text-xl py-2 font-black
     }
 
+    .markdown h5 {
+        @apply text-lg py-2 font-black
+    }
+
     .markdown p {
         @apply py-2 text-lg
     }

--- a/input.css
+++ b/input.css
@@ -58,7 +58,7 @@
     }
 
     /* Footnote element followed by a paragraph need to to change the display to inline. */
-    .markdown .footnote-definition  p{
+    .markdown .footnote-definition  p {
         @apply inline bg-gray-50 text-xs text-gray-500 ms-2
     }
 
@@ -90,6 +90,7 @@
     .markdown pre > code {
         @apply text-gray-500 ms-1 me-1 font-mono text-sm bg-transparent
     }
+
     /** Table **/
     .markdown tbody tr {
         @apply border-b-2 border-gray-100 align-text-top;

--- a/static/output.css
+++ b/static/output.css
@@ -1672,6 +1672,14 @@ input:checked + .toggle-bg {
   font-weight: 900;
 }
 
+.markdown h5 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 900;
+}
+
 .markdown p {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -1747,7 +1755,7 @@ input:checked + .toggle-bg {
 
 .markdown a.zola-anchor:hover {
   --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity));
+  color: rgb(107 114 128 / var(--tw-text-opacity));
 }
 
 .markdown li ul {

--- a/static/output.css
+++ b/static/output.css
@@ -1688,23 +1688,39 @@ input:checked + .toggle-bg {
 }
 
 .markdown ul {
-  margin-inline-start: 0.75rem;
-  list-style-position: inside;
+  margin-inline-start: 1.5rem;
+  list-style-position: outside;
   list-style-type: disc;
   font-size: 1.125rem;
   line-height: 1.75rem;
 }
 
 .markdown ol {
-  margin-inline-start: 0.75rem;
-  list-style-position: inside;
+  margin-inline-start: 1.5rem;
+  list-style-position: outside;
   list-style-type: decimal;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
 }
 
 /* Ordered elements sometimes have a paragraph and even images inside it, need to change the display to inline */
 
 .markdown ol p {
   display: inline;
+}
+
+.markdown li {
+  padding-inline-start: 0.5rem;
+}
+
+/* Nested list items look nicer with different bullets, but tailwind doesn't support them */
+
+.markdown li ul {
+  list-style-type: circle;
+}
+
+.markdown li li ul {
+  list-style-type: square;
 }
 
 /* Footnote element followed by a paragraph need to to change the display to inline. */
@@ -1756,14 +1772,6 @@ input:checked + .toggle-bg {
 .markdown a.zola-anchor:hover {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
-}
-
-.markdown li ul {
-  margin-inline-start: 1.5rem;
-  list-style-position: inside;
-  list-style-type: disc;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
 }
 
 .markdown img {


### PR DESCRIPTION
1. Adds some styling to `h5` elements, so they're not smaller or thinner than the paragraph text
    <img width="313" alt="Screenshot 2024-12-02 at 7 50 56 pm" src="https://github.com/user-attachments/assets/b2ee66e4-51dd-439b-9db6-ba736ab8b58a">
1. Fixes #15:
    <img width="400" alt="Screenshot 2024-12-02 at 7 43 34 pm" src="https://github.com/user-attachments/assets/cdc4f8b2-3add-47f3-b296-27ee5ed4d529">