### PR TITLE
version-selector: add staleness indication

### DIFF
--- a/templates/version_selector.html
+++ b/templates/version_selector.html
@@ -26,12 +26,27 @@
     function fetch_version_list(data){
         const select = document.getElementById('version_selector');
         const base_url = select.getAttribute("base_url")
+        const stabilityColors = {
+            dev:"RebeccaPurple",
+            stable:"Green",
+            recent:"Peru",
+            old:"DarkRed",
+            archived:"DimGrey",
+            unknown:"#135da3"
+        }
+
 
         data.forEach(function(entry){
             const opt = document.createElement('option');
 
             if (base_url.includes(entry[0])) {
                 opt.setAttribute('selected', true);
+                // set colour based on stability of release
+                select.style.background = stabilityColors[entry[2] ?? "unknown"]
+                // add the dropdown arrow back in -_-
+                select.style.backgroundImage = "url(\"data:image/svg+xml;charset=utf-8,<svg width='22' height='6' xmlns='http:%2F%2Fwww.w3.org/2000/svg'><path d='M1 1l4 4 4-4' fill='none' stroke='grey' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>\")";
+                select.style.backgroundRepeat = "no-repeat";
+                select.style.backgroundPosition = "right";
             }
 
             opt.value = entry[0];


### PR DESCRIPTION
Relevant to #23, although there's still room for improvement (e.g. with some explanatory text somewhere, instead of just colours).

Expects a versions `.json` file like:

```data.json
[
    ["/docs/latest/", "Latest", "dev"], 
    ["/docs/stable/", "1.3 (stable)", "stable"], 
    ["/docs/1.2/", "1.2", "recent"], 
    ["/docs/1.1/", "1.1", "old"], 
    ["/docs/1.0/", "1.0", "archived"]
]
```

Might be worth consulting SMS on the colours 🤷‍♂️ 

**Existing:**

<img width="319" alt="Screenshot 2024-12-13 at 4 52 06 pm" src="https://github.com/user-attachments/assets/853315f9-e8a5-4090-9017-22f2c9786c1e" />

---

**Version indicator after PR:**

<img width="138" alt="Screenshot 2024-12-13 at 11 46 53 pm" src="https://github.com/user-attachments/assets/e21f8b43-28ce-4418-b71a-adc7591cbe4d" />
<img width="138" alt="Screenshot 2024-12-14 at 12 43 52 am" src="https://github.com/user-attachments/assets/16fd4867-7235-447d-9f00-4b05ba8526d8" />
<img width="138" alt="Screenshot 2024-12-13 at 11 46 34 pm" src="https://github.com/user-attachments/assets/95392379-c974-42e9-806b-b08e432d5b10" />
<img width="138" alt="Screenshot 2024-12-13 at 11 46 29 pm" src="https://github.com/user-attachments/assets/c8a5cb0f-dee1-4925-a947-04be5cacd010" />
<img width="138" alt="Screenshot 2024-12-13 at 11 46 23 pm" src="https://github.com/user-attachments/assets/fb6d660d-fb5c-4120-a96f-3c55a4401688" />