### PR TITLE
README: add links to current users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # bluetheme
-A Zola theme...
+A [Zola](https://www.getzola.org/) theme for documenting Blue Robotics' software applications.
 
-** install tailwind and flowbite **
+## Currently Used In...
+
+- [BlueOS-docs](https://github.com/bluerobotics/BlueOS-docs)
+- [Cockpit-docs](https://github.com/bluerobotics-Cockpit-docs)
+
+## Local Usage
+
+1. install dependencies (e.g. tailwind and flowbite)
 
     npm install
 
-** generate the output.css file **
+2. generate the output.css file
 
     npx tailwindcss -i ./input.css -o ./static/output.css --watch
 


### PR DESCRIPTION
People wanting to contribute to the docs do not currently have a direct route to finding their source from in the docs themselves, but they do have a link to the theme repo, so this could help others contribute to our docs :-)