### PR TITLE
templates: navbar: default to static logo

### DIFF
--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,18 +1,10 @@
-
-<!-- define variable to where the logo should redirect to -->
-{% if config.extra.logo.redirect_to %}
-    {% set logo_redirect_to = config.extra.logo.redirect_to %}
-{% else %}
-    {% set logo_redirect_to = config.base_url | safe %}
-{% endif %}
-
 <nav class=" border-b-0 border-gray-200 top-0 start-0 z-40 fixed w-full">
     <div class="w-full bg-primary px-4 py-1.5">
         <div class="container mx-auto ">
             <div class="flex flex-wrap justify-between items-center">
                 <div class="flex justify-start items-center">
-                    <a href="{{ logo_redirect_to }}" class="flex mr-4">
-                        <img src="{{ config.extra.logo.image_source }}"
+                    <a href="{{ config.extra.logo.redirect_to | default(value=config.base_url | safe) }}" class="flex mr-4">
+                        <img src="{{ config.extra.logo.image_source | default(value=config.base_url ~ "/logo.png") }}"
                              class="mr-3 h-10"
                              alt="Software Logo"/>
                         <span class="self-center text-2xl font-semibold whitespace-nowrap text-white"></span>

--- a/theme.toml
+++ b/theme.toml
@@ -26,9 +26,9 @@ include_content = true
 
 # ---------------------- NAVBAR ---------------------- #
 [extra.logo]
-# The path to the navbar logo image
-image_source = "https://blueos.cloud/assets/img/blueos-logo-white.png"
-# The place where the logo in the navbar should link to, e.g.
+# The path to the navbar logo image - defaults to a logo.png file in the "static" folder
+#image_source = "https://blueos.cloud/assets/img/blueos-logo-white.png"
+# The place where the logo in the navbar should link to - defaults to config.base_url
 #redirect_to = "/docs/"
 
 # If you enable this option, a select widget will be available to switch between different versions.


### PR DESCRIPTION
Building on the internalisation efforts from #45, this makes it possible to include a local logo file in the navbar (located at `static/logo.png`), instead of requiring a separately hosted one or an inflexible base-url.