### PR TITLE
templates: version_selector: include hash

### DIFF
--- a/templates/version_selector.html
+++ b/templates/version_selector.html
@@ -21,7 +21,7 @@
         let base_index = split_path.indexOf(redirect_parts[0])
         split_path.splice(base_index, redirect_parts.length - offset, ...redirect_parts)
 
-        window.location = split_path.join("/")
+        window.location = split_path.join("/") + window.location.hash
     }
 
     function fetch_version_list(data){


### PR DESCRIPTION
If you're at a specific section, it's nice to maintain that in the other version (if possible).